### PR TITLE
Change is_ssl() function to work with containers

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -3,7 +3,7 @@ FROM php:5.6-apache
 RUN a2enmod rewrite expires
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev patch && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mysqli opcache
 
@@ -29,6 +29,12 @@ RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VER
 	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
 	&& rm wordpress.tar.gz \
 	&& chown -R www-data:www-data /usr/src/wordpress
+
+# install functions.php which changes how is_ssl is called so we can glue
+# an SSL terminating container in front
+RUN mkdir /patch
+COPY is_ssl.patch /patch
+RUN cd /usr/src/wordpress && patch wp-includes/functions.php < /patch/is_ssl.patch
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/apache/is_ssl.patch
+++ b/apache/is_ssl.patch
@@ -1,0 +1,16 @@
+4026,4034c4026,4030
+< 	if ( isset($_SERVER['HTTPS']) ) {
+< 		if ( 'on' == strtolower($_SERVER['HTTPS']) )
+< 			return true;
+< 		if ( '1' == $_SERVER['HTTPS'] )
+< 			return true;
+< 	} elseif ( isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
+< 		return true;
+< 	}
+< 	return false;
+---
+>         $url = get_option( 'siteurl' );
+>         if ( substr ( $url, 0, 8 ) === "https://" ) {
+>             return true;
+>         }
+>         return false;


### PR DESCRIPTION
This is a hack to make the Wordpress more container friendly for TLS.  Right
now it tries to guess the TLS scheme by introspecting whether the server
it's running on is using TLS or not, and it ignores the 'siteurl'.  The
problem with this is that if you want to do TLS termination by bolting on
a proxy container, it will munge many of your URLs to be "http://" instead
of "https://".

This change makes it so that the is_ssl() function checks the 'siteurl'
scheme instead.